### PR TITLE
Suggestion for keybinding scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Looking to use a different keybinding? Copy the following to your
 `~/.atom/keymap.cson` to tweak:
 
 ```coffee
-'.editor':
+'.active.pane':
   'ctrl-space': 'autocomplete:toggle'
 ```
 


### PR DESCRIPTION
I immediately tried to map autocomplete to the `esc` key (I'm coming from TextMate). Once I had done so, the `esc` key would no longer do useful things, like close the ‘find’ pane, and dismiss the command palette.

Using `.active.pane` as the scope instead of `.editor` fixed my problem!
