### PR TITLE
WIP: Inclusion Of Provider + Suggestion + External Package Trigger API

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -179,3 +179,13 @@ class AutocompleteView extends SelectListView
     super
 
     @setPosition()
+
+  ###
+   * Clean up, stop listening to events
+   * @public
+  ###
+  dispose: ->
+    # @currentBuffer?.off "changed", @onChanged
+    # @currentBuffer?.off "saved", @onSaved
+    # @editor.off "title-changed-subscription-removed", @cancel
+    # @editor.off "cursor-moved", @cursorMoved

--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -1,5 +1,7 @@
 _ = require 'underscore-plus'
 AutocompleteView = require './autocomplete-view'
+Provider = require "./provider"
+Suggestion = require "./suggestion"
 
 module.exports =
   configDefaults:
@@ -14,11 +16,39 @@ module.exports =
         autocompleteView = new AutocompleteView(editor)
         editor.on 'editor:will-be-removed', =>
           autocompleteView.remove() unless autocompleteView.hasParent()
+          autocompleteView.dispose()
           _.remove(@autocompleteViews, autocompleteView)
         @autocompleteViews.push(autocompleteView)
 
   deactivate: ->
     @editorSubscription?.off()
     @editorSubscription = null
-    @autocompleteViews.forEach (autocompleteView) -> autocompleteView.remove()
+    @autocompleteViews.forEach (autocompleteView) =>
+      autocompleteView.remove()
+      autocompleteView.dispose()
     @autocompleteViews = []
+
+  ###
+   * Finds the autocomplete view for the given EditorView
+   * and registers the given provider
+   * @param  {Provider} provider
+   * @param  {EditorView} editorView
+  ###
+  registerProviderForEditorView: (provider, editorView) ->
+    autocompleteView = _.findWhere @autocompleteViews, editorView: editorView
+    unless autocompleteView?
+      throw new Error("Could not register provider", provider.constructor.name)
+
+    autocompleteView.registerProvider provider
+
+  ###
+   * Finds the autocomplete view for the given EditorView
+   * and unregisters the given provider
+   * @param  {Provider} provider
+   * @param  {EditorView} editorView
+  ###
+  unregisterProvider: (provider) ->
+    view.unregisterProvider for view in @autocompleteViews
+
+  Provider: Provider
+  Suggestion: Suggestion

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,0 +1,66 @@
+###
+ * A provider provides an interface to the autocomplete package. Third-party
+ * packages can register providers which will then be used to generate the
+ * suggestions list.
+###
+
+module.exports =
+class Provider
+  wordRegex: /\b\w*[a-zA-Z_]\w*\b/g
+  constructor: (@editorView) ->
+    {@editor} = editorView
+    @initialize.apply this, arguments
+
+  ###
+   * An an initializer for subclasses
+   * @private
+  ###
+  initialize: ->
+    return
+
+  ###
+   * Defines whether the words returned at #buildWordList() should be added to
+   * the default suggestions or should be displayed exclusively
+   * @type {Boolean}
+  ###
+  exclusive: false
+
+  ###
+   * Gets called when the document has been changed. Returns an array with
+   * suggestions. If `exclusive` is set to true and this method returns suggestions,
+   * the suggestions will be the only ones that are displayed.
+   * @return {Array}
+   * @public
+  ###
+  buildSuggestions: ->
+    throw new Error "Subclass must implement a buildWordList(prefix) method"
+
+  ###
+   * Gets called when a suggestion has been confirmed by the user. Return true
+   * to replace the word with the suggestion. Return false if you want to handle
+   * the behavior yourself.
+   * @param  {Suggestion} suggestion
+   * @return {Boolean}
+   * @public
+  ###
+  confirm: (suggestion) ->
+    return true
+
+  ###
+   * Finds and returns the content before the current cursor position
+   * @param {Selection} selection
+   * @return {String}
+   * @private
+  ###
+  prefixOfSelection: (selection) ->
+    selectionRange = selection.getBufferRange()
+    lineRange = [[selectionRange.start.row, 0], [selectionRange.end.row, @editor.lineLengthForBufferRow(selectionRange.end.row)]]
+    prefix = ""
+    @editor.getBuffer().scanInRange @wordRegex, lineRange, ({match, range, stop}) ->
+      stop() if range.start.isGreaterThan(selectionRange.end)
+
+      if range.intersectsWith(selectionRange)
+        prefixOffset = selectionRange.start.column - range.start.column
+        prefix = match[0][0...prefixOffset] if range.start.isLessThan(selectionRange.start)
+
+    return prefix

--- a/lib/suggestion.coffee
+++ b/lib/suggestion.coffee
@@ -1,0 +1,7 @@
+module.exports =
+class Suggestion
+  constructor: (@provider, options) ->
+    @word = options.word if options.word?
+    @prefix = options.prefix if options.prefix?
+    @label = options.label if options.label?
+    @data = options.data if options.data?


### PR DESCRIPTION
WIP: This PR will address #10 and #18. 

A massive hat-tip must go to the [autocomplete-plus](https://github.com/saschagehlich/autocomplete-plus) team for the content of this PR, which was motivated by a suggestion in https://github.com/saschagehlich/autocomplete-plus/issues/38. 

The goal of this PR is to:
- Provide an event-based API for external actors (e.g. packages) to trigger autocomplete in a view
- Provide an event-based provider API for external actors (e.g. packages) to augment the default autocomplete provider with more specific suggestions for a view

Tasks:
- [x] Add Provider
- [x] Add Suggestion
- [x] Update autocomplete.coffee
- [ ] Decouple default autocompletion from view
- [ ] Add Provider API to view
- [ ] Add FuzzyProvider
- [ ] Add simple-select-list-view
- [ ] Establish and document events
- [ ] Make Provider API asynchronous + event-based
- [ ] Make View display asynchronous + event-based
