### PR TITLE
Autocomplete view go past its parent right limit

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -115,8 +115,12 @@ class AutocompleteView extends SelectListView
   setPosition: ->
     { left, top } = @editorView.pixelPositionForScreenPosition(@originalCursorPosition)
     height = @outerHeight()
+    width = @outerWidth()
     potentialTop = top + @editorView.lineHeight
     potentialBottom = potentialTop - @editorView.scrollTop() + height
+    parentWidth = @parent().width()
+
+    left = parentWidth - width if left + width > parentWidth
 
     if @aboveCursor or potentialBottom > @editorView.outerHeight()
       @aboveCursor = true


### PR DESCRIPTION
When autocomplete is triggered on the rightmost part of a line, the popup doesn't snap to its parent limit and is partially cropped: 

![](http://i.imgur.com/vUNUQvd.png)

It should actually stick to the right edge, like this: 

![](http://i.imgur.com/2UWm6go.png)
