### PR TITLE
Autocomplete only insert text in the last selection

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -103,6 +103,8 @@ class AutocompleteView extends SelectListView
     @originalSelectionBufferRanges = @editor.getSelections().map (selection) -> selection.getBufferRange()
     @originalCursorPosition = @editor.getCursorScreenPosition()
 
+    return @cancel() unless @allPrefixAndSuffixOfSelectionsMatch()
+
     @buildWordList()
     matches = @findMatchesForCurrentSelection()
     @setItems(matches)
@@ -174,6 +176,17 @@ class AutocompleteView extends SelectListView
         suffix = match[0][suffixOffset..] if range.end.isGreaterThan(selectionRange.end)
 
     {prefix, suffix}
+
+  allPrefixAndSuffixOfSelectionsMatch: ->
+    {prefix, suffix} = {}
+
+    @editor.getSelections().every (selection) =>
+      [previousPrefix, previousSuffix] = [prefix, suffix]
+
+      {prefix, suffix} = @prefixAndSuffixOfSelection(selection)
+
+      return true unless previousPrefix? and previousSuffix?
+      prefix is previousPrefix and suffix is previousSuffix
 
   afterAttach: (onDom) ->
     if onDom

--- a/spec/autocomplete-spec.coffee
+++ b/spec/autocomplete-spec.coffee
@@ -139,6 +139,35 @@ describe "AutocompleteView", ->
           expect(autocomplete.list.find('li:eq(0)')).toHaveText('Some')
           expect(autocomplete.list.find('li:eq(1)')).toHaveText('sort')
 
+      describe 'where many cursors are defined', ->
+        it 'autocompletes word when there is only a prefix', ->
+          editor.getBuffer().insert([10,0] ,"s:extra:s")
+          editor.setSelectedBufferRanges([[[10,1],[10,1]], [[10,9],[10,9]]])
+          autocomplete.attach()
+
+          expect(editor.lineForBufferRow(10)).toBe "shift:extra:shift"
+          expect(editor.getCursorBufferPosition()).toEqual [10,12]
+          expect(editor.getSelection().getBufferRange()).toEqual [[10,8], [10,12]]
+
+          expect(editor.getSelections().length).toEqual(2)
+
+          expect(autocomplete.list.find('li').length).toBe 2
+          expect(autocomplete.list.find('li:eq(0)')).toHaveText('shift')
+          expect(autocomplete.list.find('li:eq(1)')).toHaveText('sort')
+
+        describe 'where text differs between cursors', ->
+          it 'cancels the autocomplete', ->
+            editor.getBuffer().insert([10,0] ,"s:extra:a")
+            editor.setSelectedBufferRanges([[[10,1],[10,1]], [[10,9],[10,9]]])
+            autocomplete.attach()
+
+            expect(editor.lineForBufferRow(10)).toBe "s:extra:a"
+            expect(editor.getSelections().length).toEqual(2)
+            expect(editor.getSelections()[0].getBufferRange()).toEqual [[10,1], [10,1]]
+            expect(editor.getSelections()[1].getBufferRange()).toEqual [[10,9], [10,9]]
+
+            expect(editorView.find('.autocomplete')).not.toExist()
+
     describe "when text is selected", ->
       it 'autocompletes word when there is only a prefix', ->
         editor.getBuffer().insert([10,0] ,"extra:sort:extra")


### PR DESCRIPTION
When there's many selections and a value is selection in the autocomplete popup only the last selection is modified: 

![screenshot](http://i.imgur.com/wct0H6w.gif)
