### PR TITLE
Use checkpoints instead of open-ended transactions

### DIFF
--- a/spec/autocomplete-spec.coffee
+++ b/spec/autocomplete-spec.coffee
@@ -146,6 +146,15 @@ describe "AutocompleteView", ->
         expect(editor.getCursorBufferPosition()).toEqual [10,10]
         expect(editor.getSelection().isEmpty()).toBeTruthy()
 
+      it "allows the completion to be undone as a single operation", ->
+        editor.getBuffer().insert([10,0] ,"extra:s:extra")
+        editor.setCursorBufferPosition([10,7])
+        autocomplete.attach()
+
+        editor.undo()
+
+        expect(editor.lineForBufferRow(10)).toBe "extra:s:extra"
+
       describe "when `autocomplete.includeCompletionsFromAllBuffers` is true", ->
         it "shows words from all open buffers", ->
           atom.config.set('autocomplete.includeCompletionsFromAllBuffers', true)


### PR DESCRIPTION
This can't be merged until atom/atom@bf83fb7b10091d7c76c489330b46cd0f96682478 is released in v0.151.

Closes #50.

This fixes issues with undo/redo after autocomplete and also makes autocomplete compatible with [vim-mode](https://github.com/atom/vim-mode).
