### PR TITLE
Use new API for atom.config.get

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -57,7 +57,7 @@ class AutocompleteView extends SelectListView
 
   getCompletionsForCursorScope: ->
     cursorScope = @editor.scopeDescriptorForBufferPosition(@editor.getCursorBufferPosition())
-    completions = atom.config.get(cursorScope, 'editor.completions')
+    completions = atom.config.get('editor.completions', scope: cursorScope)
     _.uniq(_.flatten(completions))
 
   buildWordList: ->


### PR DESCRIPTION
:warning: Depends on atom/atom@a1b4820c044073d2e46d0e2505ae7a1ee7e89272 being released in v0.166 :warning:
