### PR TITLE
List all completions that match cursor scope

### DIFF
--- a/lib/autocomplete-view.coffee
+++ b/lib/autocomplete-view.coffee
@@ -57,8 +57,8 @@ class AutocompleteView extends SelectListView
 
   getCompletionsForCursorScope: ->
     scope = @editor.scopeDescriptorForBufferPosition(@editor.getCursorBufferPosition())
-    completions = atom.config.get('editor.completions', {scope})
-    _.uniq(_.flatten(completions))
+    completions = atom.config.getAll('editor.completions', {scope})
+    _.uniq(_.flatten(_.pluck(completions, 'value')))
 
   buildWordList: ->
     wordHash = {}

--- a/spec/autocomplete-spec.coffee
+++ b/spec/autocomplete-spec.coffee
@@ -517,6 +517,7 @@ describe "AutocompleteView", ->
       atom.workspace.open('css.css').then (editor) -> cssEditor = editor
 
     runs ->
+      atom.config.set('editor.completions', ["outrigger"], scopeSelector: '.source')
       autocomplete = new AutocompleteView(cssEditor)
 
       cssEditor.moveToEndOfLine()
@@ -524,9 +525,10 @@ describe "AutocompleteView", ->
       cssEditor.moveToEndOfLine()
 
       autocomplete.attach()
-      expect(autocomplete.list.find('li').length).toBe 5
+      expect(autocomplete.list.find('li').length).toBe 6
       expect(autocomplete.list.find('li:eq(0)')).toHaveText 'outline'
       expect(autocomplete.list.find('li:eq(1)')).toHaveText 'outline-color'
       expect(autocomplete.list.find('li:eq(2)')).toHaveText 'outline-offset'
       expect(autocomplete.list.find('li:eq(3)')).toHaveText 'outline-style'
       expect(autocomplete.list.find('li:eq(4)')).toHaveText 'outline-width'
+      expect(autocomplete.list.find('li:eq(5)')).toHaveText 'outrigger'


### PR DESCRIPTION
:warning: Depends on atom/atom@c7771ffde90ac0e79dd577f912d840134a96fb7c being released :warning: